### PR TITLE
Add optional root shell timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ If a different module manages Kerberos for root, disable Kerberos in this module
 root::manage_kerberos: false
 ```
 
+Set an automatic logout for idle interactive shells (in seconds):
+
+```yaml
+root::logout_timeout: 600
+```
+
 ## Reference
 
 [http://treydock.github.io/puppet-module-root/](http://treydock.github.io/puppet-module-root/)

--- a/spec/classes/root_spec.rb
+++ b/spec/classes/root_spec.rb
@@ -73,6 +73,14 @@ describe 'root' do
 
       it { is_expected.to contain_mailalias('root').with_ensure('absent') }
 
+      it do
+        is_expected.to contain_file('/etc/profile.d/root_logout_timeout.csh').with(ensure: 'absent')
+      end
+
+      it do
+        is_expected.to contain_file('/etc/profile.d/root_logout_timeout.sh').with(ensure: 'absent')
+      end
+
       context 'authorized_keys as an Array' do
         let(:params) { { ssh_authorized_keys: ['ssh-rsa longhashfoo== foo', 'ssh-dss longhashbar== bar'] } }
 
@@ -131,6 +139,57 @@ describe 'root' do
           is_expected.to contain_mailalias('root').with(ensure: 'present',
                                                         recipient: ['foo', 'bar'],
                                                         notify: 'Exec[root newaliases]')
+        end
+      end
+
+      context 'with timeout set over 1 minute' do
+        let(:params) { { logout_timeout: 90 } }
+
+        it do
+          is_expected.to contain_file('/etc/profile.d/root_logout_timeout.csh').with(ensure: 'file',
+                                                                                     owner: 'root',
+                                                                                     group: 'root',
+                                                                                     mode: '0644').with_content(%r{^\s*set -r autologout 1$})
+        end
+        it do
+          is_expected.to contain_file('/etc/profile.d/root_logout_timeout.sh').with(ensure: 'file',
+                                                                                    owner: 'root',
+                                                                                    group: 'root',
+                                                                                    mode: '0644').with_content(%r{^\s*TMOUT=90$})
+        end
+      end
+
+      context 'with timeout set less than 1 minute' do
+        let(:params) { { logout_timeout: 20 } }
+
+        it do
+          is_expected.to contain_file('/etc/profile.d/root_logout_timeout.csh').with(ensure: 'file',
+                                                                                     owner: 'root',
+                                                                                     group: 'root',
+                                                                                     mode: '0644').with_content(%r{^\s*set -r autologout 1$})
+        end
+        it do
+          is_expected.to contain_file('/etc/profile.d/root_logout_timeout.sh').with(ensure: 'file',
+                                                                                    owner: 'root',
+                                                                                    group: 'root',
+                                                                                    mode: '0644').with_content(%r{^\s*TMOUT=20$})
+        end
+      end
+
+      context 'with timeout set to 0' do
+        let(:params) { { logout_timeout: 0 } }
+
+        it do
+          is_expected.to contain_file('/etc/profile.d/root_logout_timeout.csh').with(ensure: 'file',
+                                                                                     owner: 'root',
+                                                                                     group: 'root',
+                                                                                     mode: '0644').with_content(%r{^\s*set -r autologout 0$})
+        end
+        it do
+          is_expected.to contain_file('/etc/profile.d/root_logout_timeout.sh').with(ensure: 'file',
+                                                                                    owner: 'root',
+                                                                                    group: 'root',
+                                                                                    mode: '0644').with_content(%r{^\s*TMOUT=0$})
         end
       end
 

--- a/templates/root_logout_timeout.csh.erb
+++ b/templates/root_logout_timeout.csh.erb
@@ -1,0 +1,11 @@
+# File managed by Puppet (root::logout_timeout = <%= scope['root::logout_timeout'] %>), DO NOT EDIT
+<% if scope['root::logout_timeout'] -%>
+<%   inminutes = Integer(scope['root::logout_timeout'] / 60) -%>
+<%   if scope['root::logout_timeout'] > 0  && inminutes == 0 -%>
+<%#  csh defines in minutes not seconds, cover edge case <60 seconds -%>
+<%     inminutes = 1 -%>
+<%   end -%>
+if ( `id -u` == "0" ) then
+    set -r autologout <%= inminutes %>
+endif
+<% end -%>

--- a/templates/root_logout_timeout.sh.erb
+++ b/templates/root_logout_timeout.sh.erb
@@ -1,0 +1,7 @@
+# File managed by Puppet (root::logout_timeout = <%= scope['root::logout_timeout'] %>), DO NOT EDIT
+<% if scope['root::logout_timeout'] -%>
+if [ `id -u` = 0 ] ; then
+    TMOUT=<%= scope['root::logout_timeout'] %>
+    export TMOUT
+fi
+<% end -%>


### PR DESCRIPTION
For various Computer Security practices, it is often mandated to have a default root timeout.

This PR adds an optional timeout folks can set.