### PR TITLE
Make sure file ends in new line

### DIFF
--- a/manifests/kerberos.pp
+++ b/manifests/kerberos.pp
@@ -19,7 +19,7 @@ class root::kerberos {
   }
 
   if ! empty($_kerberos_login_principals) {
-    $k5login = ['# File managed by Puppet (root::manage_kerberos = true), DO NOT EDIT'] + $_kerberos_login_principals
+    $k5login = ['# File managed by Puppet (root::manage_kerberos = true), DO NOT EDIT'] + $_kerberos_login_principals + ['']
     file { '/root/.k5login':
       ensure  => 'file',
       owner   => 'root',


### PR DESCRIPTION
A terribly minor nit, but I just noticed that `/root/.k5login` doesn't have a newline at the end.  It isn't serious, but it is a bit ugly.

```shell
--- /root/.k5login	2022-06-01 09:42:41.564571925 -0500
+++ /tmp/puppet-file20220602-3877-7bz77z	2022-06-02 14:00:05.160575578 -0500
@@ -0,0 +1,2 @@
+# File managed by Puppet (root::manage_kerberos = true), DO NOT EDIT
+testuser@EXAMPLE.COM
\ No newline at end of file
```