### PR TITLE
BREAKING CHANGE: Remove Hiera merge parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,31 @@ root::ssh_authorized_keys:
     key: 'somelonghash=='
 ```
 
+If you wish to merge authorized keys from multiple locations:
+
+```yaml
+lookup_options:
+  root::mailaliases:
+    merge: unique
+  root::ssh_authorized_keys:
+    merge: deep
+root::mailaliases:
+  - 'root@example.com'
+root::ssh_authorized_keys:
+  user@fqdn:
+    type: 'ssh-rsa'
+    key: 'somelonghash=='
+# Some other Hiera location:
+root::mailaliases:
+  - 'root@example2.com'
+root::ssh_authorized_keys:
+  user2@fqdn:
+    type: 'ssh-rsa'
+    key: 'somelonghash=='
+```
+
+If you use Arrays for resources like `root::ssh_authorized_keys` then use `unique` merge instead of `deep`.
+
 To export a system's root RSA key
 
 ```yaml

--- a/manifests/kerberos.pp
+++ b/manifests/kerberos.pp
@@ -1,25 +1,8 @@
 # @summary Private class
 # @api private
 class root::kerberos {
-  $kerberos_login_principals_hiera_merge = $root::kerberos_login_principals_hiera_merge
-  $kerberos_login_principals = $root::kerberos_login_principals
-  $kerberos_users_commands_hiera_merge = $root::kerberos_users_commands_hiera_merge
-  $kerberos_users_commands = $root::kerberos_users_commands
-
-  if $kerberos_login_principals_hiera_merge {
-    $_kerberos_login_principals = lookup('root::kerberos_login_principals', Array, 'unique', $kerberos_login_principals)
-  } else {
-    $_kerberos_login_principals = $kerberos_login_principals
-  }
-
-  if $kerberos_users_commands_hiera_merge {
-    $_kerberos_users_commands = lookup('root::kerberos_users_commands', Hash, { 'strategy' => 'deep', 'merge_hash_arrays' => true }, $kerberos_users_commands)
-  } else {
-    $_kerberos_users_commands = $kerberos_users_commands
-  }
-
-  if ! empty($_kerberos_login_principals) {
-    $k5login = ['# File managed by Puppet (root::manage_kerberos = true), DO NOT EDIT'] + $_kerberos_login_principals + ['']
+  if ! empty($root::kerberos_login_principals) {
+    $k5login = ['# File managed by Puppet (root::manage_kerberos = true), DO NOT EDIT'] + $root::kerberos_login_principals + ['']
     file { '/root/.k5login':
       ensure  => 'file',
       owner   => 'root',
@@ -31,7 +14,7 @@ class root::kerberos {
     file { '/root/.k5login': ensure => 'absent' }
   }
 
-  if ! empty($_kerberos_users_commands) {
+  if ! empty($root::kerberos_users_commands) {
     file { '/root/.k5users':
       ensure  => 'file',
       owner   => 'root',

--- a/templates/k5users.erb
+++ b/templates/k5users.erb
@@ -1,5 +1,5 @@
 # File managed by Puppet (root::manage_kerberos = true), DO NOT EDIT
-<%- @_kerberos_users_commands.each_pair do |user, commands| -%>
+<%- scope['root::kerberos_users_commands'].each_pair do |user, commands| -%>
 <%-
 if commands.is_a?(Array)
   commands = commands.join(' ')


### PR DESCRIPTION
Remove the following parameters in favor of using `lookup_options`
* mailaliases_hiera_merge
* ssh_authorized_keys_hiera_merge
* kerberos_login_principals_hiera_merge
* kerberos_users_commands_hiera_merge