### PR TITLE
Note compatibility with stdlib 9.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,15 +10,15 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 <9.0.0"
+      "version_requirement": ">= 4.13.1 < 10.0.0"
     },
     {
       "name": "puppetlabs/mailalias_core",
-      "version_requirement": ">= 1.0.0 <2.0.0"
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     },
     {
       "name": "puppetlabs/sshkeys_core",
-      "version_requirement": ">= 1.0.0 <3.0.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Fixes https://github.com/treydock/puppet-module-root/issues/27

Local tests with stdlib 9 all passed.